### PR TITLE
Add manual translate as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Alternative front-end for Google Translate, serving as a Free and Open Source tr
 
 ## How does it work?
 
-Inspired by projects like [NewPipe](https://github.com/TeamNewPipe/NewPipe), [Nitter](https://github.com/zedeus/nitter), [Invidious](https://github.com/iv-org/invidious) or [Bibliogram](https://git.sr.ht/~cadence/bibliogram), *Lingva* scrappes through GTranslate and retrieves the translation without using any Google-related service, preventing them from tracking.
+Inspired by projects like [NewPipe](https://github.com/TeamNewPipe/NewPipe), [Nitter](https://github.com/zedeus/nitter), [Invidious](https://github.com/iv-org/invidious) or [Bibliogram](https://git.sr.ht/~cadence/bibliogram), *Lingva* scrapes through GTranslate and retrieves the translation without using any Google-related service, preventing them from tracking.
 
 For this purpose, *Lingva* is built, among others, with the following Open Source resources:
 

--- a/components/AutoTranslateButton.tsx
+++ b/components/AutoTranslateButton.tsx
@@ -1,0 +1,38 @@
+import { useState, useEffect, FC } from "react";
+import { IconButton } from "@chakra-ui/react";
+import { FaBolt } from "react-icons/fa";
+
+type Props = {
+    onAuto: () => void,
+    [key: string]: any
+};
+
+const initLocalStorage = () => {
+    const initial = typeof window !== "undefined" && localStorage.getItem("isauto");
+    return initial ? initial === "true" : false;
+};
+
+const AutoTranslateButton: FC<Props> = ({ onAuto, ...props }) => {
+    const [isAuto, setIsAuto] = useState(initLocalStorage);
+
+    useEffect(() => {
+        localStorage.setItem("isauto", isAuto.toString());
+    }, [isAuto]);
+
+    useEffect(() => {
+        isAuto && onAuto();
+    }, [isAuto, onAuto]);
+
+    return (
+        <IconButton
+            aria-label="Switch auto"
+            icon={<FaBolt />}
+            colorScheme="lingva"
+            variant={isAuto ? "solid" : "outline"}
+            onClick={() => setIsAuto(current => !current)}
+            {...props}
+        />
+    );
+};
+
+export default AutoTranslateButton;

--- a/components/LangSelect.tsx
+++ b/components/LangSelect.tsx
@@ -13,7 +13,7 @@ const LangSelect: FC<Props> = ({ value, onChange, langs, ...props }) => (
         value={value}
         onChange={onChange}
         variant="flushed"
-        px={2}
+        px={3}
         textAlign="center"
         style={{ textAlignLast: "center" }}
         {...props}

--- a/components/TranslationArea.tsx
+++ b/components/TranslationArea.tsx
@@ -1,11 +1,12 @@
-import { FC, ChangeEvent } from "react";
-import { Box, HStack, Textarea, IconButton, Tooltip, Spinner, useBreakpointValue, useColorModeValue, useClipboard } from "@chakra-ui/react";
+import { FC } from "react";
+import { Box, HStack, Textarea, IconButton, Tooltip, Spinner, TextareaProps, useBreakpointValue, useColorModeValue, useClipboard } from "@chakra-ui/react";
 import { FaCopy, FaCheck, FaPlay, FaStop } from "react-icons/fa";
 import { useAudioFromBuffer } from "@hooks";
 
 type Props =  {
     value: string,
-    onChange?: (e: ChangeEvent<HTMLTextAreaElement>) => void,
+    onChange?: TextareaProps["onChange"],
+    onSubmit?: () => void,
     readOnly?: true,
     audio?: number[],
     canCopy?: boolean,
@@ -13,7 +14,7 @@ type Props =  {
     [key: string]: any
 };
 
-const TranslationArea: FC<Props> = ({ value, onChange, readOnly, audio, canCopy, isLoading, ...props }) => {
+const TranslationArea: FC<Props> = ({ value, onChange, onSubmit, readOnly, audio, canCopy, isLoading, ...props }) => {
     const { hasCopied, onCopy } = useClipboard(value);
     const { audioExists, isAudioPlaying, onAudioClick } = useAudioFromBuffer(audio);
     const spinnerProps = {
@@ -36,6 +37,7 @@ const TranslationArea: FC<Props> = ({ value, onChange, readOnly, audio, canCopy,
                 rows={useBreakpointValue([6, null, 12]) ?? undefined}
                 size="lg"
                 data-gramm_editor={false}
+                onKeyPress={e => (e.ctrlKey || e.metaKey) && e.key === "Enter" && onSubmit?.()}
                 {...props}
             />
             <HStack

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -6,3 +6,4 @@ export { default as Footer } from "./Footer";
 export { default as ColorModeToggler } from "./ColorModeToggler";
 export { default as LangSelect } from "./LangSelect";
 export { default as TranslationArea } from "./TranslationArea";
+export { default as AutoTranslateButton } from "./AutoTranslateButton";

--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -4,6 +4,7 @@ import faker from "faker";
 
 beforeEach(() => {
     cy.visit("/");
+    cy.clearLocalStorage();
 });
 
 it("switches page on inputs change & goes back correctly", () => {
@@ -11,13 +12,16 @@ it("switches page on inputs change & goes back correctly", () => {
     cy.findByRole("textbox", { name: /translation query/i })
         .as("query")
         .type("palabra");
-    cy.findByText(/loading translation/i)
-        .should("be.visible");
+    cy.findByRole("button", { name: /translate/i })
+        .click();
     cy.findByRole("textbox", { name: /translation result/i })
         .as("translation")
         .should("have.value", "word")
         .url()
         .should("include", "/auto/en/palabra");
+    cy.findByRole("button", { name: /switch auto/i })
+        .click();
+
     // source change
     cy.findByRole("combobox", { name: /source language/i })
         .as("source")
@@ -71,6 +75,9 @@ it("switches first loaded page and back and forth on language change", () => {
     const query = faker.random.words();
     cy.visit(`/auto/en/${query}`);
 
+    cy.findByRole("button", { name: /switch auto/i })
+        .click();
+
     cy.findByRole("textbox", { name: /translation query/i })
         .as("query")
         .should("have.value", query);
@@ -92,6 +99,9 @@ it("switches first loaded page and back and forth on language change", () => {
 });
 
 it("language switching button is disabled on 'auto', but enables when other", () => {
+    cy.findByRole("button", { name: /switch auto/i })
+        .click();
+
     cy.findByRole("button", { name: /switch languages/i })
         .as("btnSwitch")
         .should("be.disabled");

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
     ],
     moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
     moduleNameMapper: {
-        "^@(components|hooks|pages|public|tests|utils|theme)(.*)$": "<rootDir>/$1$2"
+        "^@(components|hooks|mocks|pages|public|tests|utils|theme)(.*)$": "<rootDir>/$1$2"
     },
     testEnvironment: "jsdom"
 }

--- a/mocks/localStorage.ts
+++ b/mocks/localStorage.ts
@@ -1,0 +1,9 @@
+Object.defineProperty(window, "localStorage", {
+    value: {
+        getItem: jest.fn(() => null),
+        setItem: jest.fn(() => null)
+    },
+    writable: true
+});
+
+export const localStorageSetMock = window.localStorage.setItem;

--- a/mocks/next.ts
+++ b/mocks/next.ts
@@ -1,0 +1,3 @@
+import Router from "next/router";
+
+export const routerPushMock = jest.spyOn(Router, "push").mockImplementation(async () => true);

--- a/pages/[[...slug]].tsx
+++ b/pages/[[...slug]].tsx
@@ -1,14 +1,18 @@
-import { useEffect, useReducer, FC, ChangeEvent } from "react";
+import { useEffect, useReducer, useCallback, FC, ChangeEvent } from "react";
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import Router from "next/router";
+import dynamic from "next/dynamic";
 import { Stack, VStack, HStack, IconButton } from "@chakra-ui/react";
 import { FaExchangeAlt } from "react-icons/fa";
+import { HiTranslate } from "react-icons/hi";
 import { useHotkeys } from "react-hotkeys-hook";
 import { CustomHead, LangSelect, TranslationArea } from "@components";
 import { useToastOnLoad } from "@hooks";
 import { googleScrape, extractSlug, textToSpeechScrape } from "@utils/translate";
 import { retrieveFiltered, replaceBoth } from "@utils/language";
 import langReducer, { Actions, initialState } from "@utils/reducer";
+
+const AutoTranslateButton = dynamic(() => import("@components/AutoTranslateButton"), { ssr: false });
 
 const Page: FC<InferGetStaticPropsType<typeof getStaticProps>> = ({ home, translationRes, audio, errorMsg, initial }) => {
     const [{ source, target, query, delayedQuery, translation, isLoading }, dispatch] = useReducer(langReducer, initialState);
@@ -22,6 +26,20 @@ const Page: FC<InferGetStaticPropsType<typeof getStaticProps>> = ({ home, transl
             }
         });
     };
+
+    const changeRoute = useCallback((customQuery: string) => {
+        if (isLoading)
+            return;
+        if (!customQuery || customQuery === initialState.query)
+            return;
+        if (!home && !initial)
+            return;
+        if (!home && customQuery === initial.query && source === initial.source && target === initial.target)
+            return;
+
+        dispatch({ type: Actions.SET_FIELD, payload: { key: "isLoading", value: true }});
+        Router.push(`/${source}/${target}/${encodeURIComponent(customQuery)}`);
+    }, [isLoading, source, target, home, initial]);
 
     useEffect(() => {
         if (home)
@@ -41,20 +59,6 @@ const Page: FC<InferGetStaticPropsType<typeof getStaticProps>> = ({ home, transl
         ), 1000);
         return () => clearTimeout(timeout);
     }, [query]);
-
-    useEffect(() => {
-        if (isLoading)
-            return;
-        if (!delayedQuery || delayedQuery === initialState.query)
-            return;
-        if (!home && !initial)
-            return;
-        if (!home && delayedQuery === initial.query && source === initial.source && target === initial.target)
-            return;
-
-        dispatch({ type: Actions.SET_FIELD, payload: { key: "isLoading", value: true }});
-        Router.push(`/${source}/${target}/${encodeURIComponent(delayedQuery)}`);
-    }, [source, target, delayedQuery, initial, home, isLoading]);
 
     useEffect(() => {
         const handler = (url: string) => url === Router.asPath || dispatch({ type: Actions.SET_FIELD, payload: { key: "isLoading", value: true }});
@@ -117,6 +121,20 @@ const Page: FC<InferGetStaticPropsType<typeof getStaticProps>> = ({ home, transl
                         lang={queryLang}
                         audio={audio?.source}
                     />
+                    <Stack direction={["row", null, "column"]} justify="center">
+                        <IconButton
+                            aria-label="Translate"
+                            icon={<HiTranslate />}
+                            colorScheme="lingva"
+                            variant="outline"
+                            onClick={() => changeRoute(query)}
+                            isDisabled={isLoading}
+                        />
+                        <AutoTranslateButton
+                            onAuto={useCallback(() => changeRoute(delayedQuery), [delayedQuery, changeRoute])}
+                            isDisabled={isLoading}
+                        />
+                    </Stack>
                     <TranslationArea
                         id="translation"
                         aria-label="Translation result"

--- a/pages/[[...slug]].tsx
+++ b/pages/[[...slug]].tsx
@@ -118,10 +118,11 @@ const Page: FC<InferGetStaticPropsType<typeof getStaticProps>> = ({ home, transl
                         placeholder="Text"
                         value={query}
                         onChange={e => isLoading || handleChange(e)}
+                        onSubmit={useCallback(() => changeRoute(query), [query, changeRoute])}
                         lang={queryLang}
                         audio={audio?.source}
                     />
-                    <Stack direction={["row", null, "column"]} justify="center">
+                    <Stack direction={["row", null, "column"]} justify="center" spacing={3} px={[2, null, "initial"]}>
                         <IconButton
                             aria-label="Translate"
                             icon={<HiTranslate />}
@@ -129,10 +130,12 @@ const Page: FC<InferGetStaticPropsType<typeof getStaticProps>> = ({ home, transl
                             variant="outline"
                             onClick={() => changeRoute(query)}
                             isDisabled={isLoading}
+                            w={["full", null, "auto"]}
                         />
                         <AutoTranslateButton
                             onAuto={useCallback(() => changeRoute(delayedQuery), [delayedQuery, changeRoute])}
                             isDisabled={isLoading}
+                            w={["full", null, "auto"]}
                         />
                     </Stack>
                     <TranslationArea

--- a/tests/utils/reducer.test.ts
+++ b/tests/utils/reducer.test.ts
@@ -65,7 +65,7 @@ it("switches the languages & the translations", () => {
         target: state.source,
         query: state.translation,
         delayedQuery: state.translation,
-        translation: "",
+        translation: state.query,
         isLoading: initialState.isLoading
     });
 });

--- a/utils/reducer.ts
+++ b/utils/reducer.ts
@@ -57,7 +57,7 @@ export default function reducer(state: State, action: Action) {
                 target,
                 query: state.translation,
                 delayedQuery: state.translation,
-                translation: ""
+                translation: state.query
             };
         default:
             return state;


### PR DESCRIPTION
Since the release of the project I decided to let translation as an automatic transition when the user stopped typing for one second. This in fact added a lot of complexity to the code but I thought it was the best. But with the time I realized, because of personal usage and of other users' feedback, that this was annoying.

With this release, Lingva disables this behaviour by default and gets two new buttons. The first one is for manually executing the translation, and the second is for enabling and disabling the auto-translate mode.

Also, resolves #30.