### PR TITLE
Save languages to LocalStorage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,3 +48,7 @@ cypress/screenshots
 .git/
 .gitignore
 .gitattributes
+
+# docker
+Dockerfile
+.dockerignore

--- a/tests/pages/[[...slug]].test.tsx
+++ b/tests/pages/[[...slug]].test.tsx
@@ -156,6 +156,7 @@ describe("Page", () => {
         expect(source).toHaveValue(sourceVal);
 
         await waitFor(() => expect(routerPushMock).toHaveBeenCalledTimes(1));
+        expect(localStorageSetMock).toHaveBeenCalledWith("source", sourceVal);
     });
 
     it("doesn't switch the page on language change on the start page", async () => {
@@ -193,6 +194,7 @@ describe("Page", () => {
         expect(screen.getByRole("textbox", { name: /translation result/i })).toHaveValue(initial.query);
 
         await waitFor(() => expect(routerPushMock).toHaveBeenCalledTimes(1));
+        expect(localStorageSetMock).toHaveBeenLastCalledWith("target", initial.source);
     });
 
     it("translates & loads initials correctly", async () => {


### PR DESCRIPTION
Saves source & target languages to localStorage on page switching. Only restores them on the homepage.
Resolves #51.