### PR TITLE
[skip ci] Add lingva.pussthecat.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ docker run -p 3000:3000 -e site_domain=lingva.ml thedaviddelta/lingva-translate:
 
 These are the currently known *Lingva* instances. Feel free to make a Pull Request including yours (please remember to add `[skip ci]` to the last commit).
 
-| Domain                                                       | Hosting                       | SSL Provider                                                                             |
-|:------------------------------------------------------------:|:-----------------------------:|:----------------------------------------------------------------------------------------:|
-| [lingva.ml](https://lingva.ml/) (Official)                   | [Vercel](https://vercel.com/) | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.ml)                |
-| [translate.alefvanoon.xyz](https://translate.alefvanoon.xyz) | [Vercel](https://vercel.com/) | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.alefvanoon.xyz) |
-| [translate.igna.rocks](https://translate.igna.rocks)         | [Vercel](https://vercel.com/) | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.igna.rocks)     |
+| Domain                                                       | Hosting                                   | SSL Provider                                                                             |
+|:------------------------------------------------------------:|:-----------------------------------------:|:----------------------------------------------------------------------------------------:|
+| [lingva.ml](https://lingva.ml/) (Official)                   | [Vercel](https://vercel.com/)             | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.ml)                |
+| [translate.alefvanoon.xyz](https://translate.alefvanoon.xyz) | [Vercel](https://vercel.com/)             | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.alefvanoon.xyz) |
+| [translate.igna.rocks](https://translate.igna.rocks)         | [Vercel](https://vercel.com/)             | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.igna.rocks)     |
+| [lingva.pussthecat.org](https://lingva.pussthecat.org)       | [PussTheCat.org](https://pussthecat.org/) | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.pussthecat.org)    |
 
 
 ## Public APIs


### PR DESCRIPTION
Add the PussTheCat.org instance.

- Deployed via Docker.

I used `[PussTheCat.org](https://pussthecat.org/)` as "hosting"... since, well, I don't use "hosting platforms" to host stuff.