### PR TITLE
Add arm64 as a build target for the docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
   apt:
     packages:
       - libgconf-2-4
+      - xvfb
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - lts/*
 
+arch:
+  - amd64
+  - arm64
+
 os: linux
 
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ arch:
 
 os: linux
 
-dist: xenial
+dist: focal
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,17 @@ addons:
   apt:
     packages:
       - libgconf-2-4
+      # Cypress dependencies
+      - libgtk2.0-0
+      - libgtk-3-0
+      - libgbm-dev
+      - libnotify-dev
+      - libgconf-2-4
+      - libnss3
+      - libxss1
+      - libasound2
+      - libxtst6
+      - xauth
       - xvfb
 
 cache:


### PR DESCRIPTION
Fixes #62 

Note: I'm not super experienced with Docker image builds and Docker container creation so it's maybe wrong.

Resource used: https://docs.travis-ci.com/user/multi-cpu-architectures/