### PR TITLE
Update instance list

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These are the currently known *Lingva* instances. Feel free to make a Pull Reque
 |:-------------------------------------------------------------------:|:-----------------------------------------:|:--------------------------------------------------------------------------------------------:|
 | [lingva.ml](https://lingva.ml/) (Official)                          | [Vercel](https://vercel.com/)             | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.ml)                    |
 | [lingva.pussthecat.org](https://lingva.pussthecat.org)              | [Hetzner](https://hetzner.com/)           | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.pussthecat.org)        |
-| [translate.plausibility.cloud](https://translate.plausibiity.cloud) | [Hetzner](https://hetzner.com/)           | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.plausibility.cloud) |
+| [translate.plausibility.cloud](https://translate.plausibility.cloud)| [Hetzner](https://hetzner.com/)           | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.plausibility.cloud) |
 | [lingva.lunar.icu](https://lingva.lunar.icu/)                       | [Lansol](https://lansol.de/)              | [Cloudflare](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.lunar.icu)                |
 
 ## Public APIs

--- a/README.md
+++ b/README.md
@@ -79,11 +79,7 @@ These are the currently known *Lingva* instances. Feel free to make a Pull Reque
 | Domain                                                              | Hosting                                   | SSL Provider                                                                                 |
 |:-------------------------------------------------------------------:|:-----------------------------------------:|:--------------------------------------------------------------------------------------------:|
 | [lingva.ml](https://lingva.ml/) (Official)                          | [Vercel](https://vercel.com/)             | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.ml)                    |
-| [translate.alefvanoon.xyz](https://translate.alefvanoon.xyz)        | [Vercel](https://vercel.com/)             | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.alefvanoon.xyz)     |
-| [translate.igna.rocks](https://translate.igna.rocks)                | [Vercel](https://vercel.com/)             | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.igna.rocks)         |
 | [lingva.pussthecat.org](https://lingva.pussthecat.org)              | [Hetzner](https://hetzner.com/)           | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.pussthecat.org)        |
-| [translate.datatunnel.xyz](https://translate.datatunnel.xyz)        | [Hetzner](https://hetzner.com/)           | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.datatunnel.xyz)     |
-| [lingva.esmailelbob.xyz](https://lingva.esmailelbob.xyz/)           | [Kimsufi](https://kimsufi.com/)           | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.esmailelbob.xyz)       |
 | [translate.plausibility.cloud](https://translate.plausibiity.cloud) | [Hetzner](https://hetzner.com/)           | [Let's Encrypt](https://www.ssllabs.com/ssltest/analyze.html?d=translate.plausibility.cloud) |
 | [lingva.lunar.icu](https://lingva.lunar.icu/)                       | [Lansol](https://lansol.de/)              | [Cloudflare](https://www.ssllabs.com/ssltest/analyze.html?d=lingva.lunar.icu)                |
 
@@ -201,5 +197,5 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 [![](https://www.gnu.org/graphics/agplv3-with-text-162x68.png)](https://www.gnu.org/licenses/agpl-3.0.html)
 
-Copyright © 2021 [TheDavidDelta](https://github.com/TheDavidDelta) & contributors.  
+Copyright © 2021 [TheDavidDelta](https://github.com/TheDavidDelta) & contributors.
 This project is [GNU AGPLv3](./LICENSE) licensed.

--- a/instances.json
+++ b/instances.json
@@ -1,10 +1,6 @@
 [
   "https://lingva.ml",
-  "https://translate.alefvanoon.xyz",
-  "https://translate.igna.rocks",
   "https://lingva.pussthecat.org",
-  "https://translate.datatunnel.xyz",
-  "https://lingva.esmailelbob.xyz",
   "https://translate.plausibility.cloud",
   "https://lingva.lunar.icu"
 ]


### PR DESCRIPTION
- alefvanoon.xyz says domain is for sale.
- igna.rocks says deployment is disabled.
- datatunnel.xyz is gone.
- lingva.esmailelbob.xyz isn't Lingva anymore, it is hosting simply translate and redirects to https://simplytranslate.esmailelbob.xyz.
- translate.plausibility.cloud had a typo (double ii ) in the hyperlink in Readme.

Rest seems to work as of today.

Fixes https://github.com/thedaviddelta/lingva-translate/issues/109
Fixes https://github.com/thedaviddelta/lingva-translate/issues/108